### PR TITLE
Add python-pip package to the list of dependencies

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -28,6 +28,7 @@
     - flex
     - gettext
     - ncurses-dev
+    - python-pip
     - zlib1g-dev
 
 - name: Install gem backup


### PR DESCRIPTION
Add python-pip package to the list of dependencies, because we want to install `awscli` via pip